### PR TITLE
Add builds for packages supporting macOS or Windows building

### DIFF
--- a/.travis-output.py
+++ b/.travis-output.py
@@ -105,7 +105,8 @@ while True:
   if not line:
     break
 
-  line = line.decode('utf-8')
+  line = line.decode('utf-8', errors='backslashreplace')
+
   logfile.write(line)
   logfile.flush()
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: minimal
+language: shell
 
 dist: xenial
 addons:
@@ -7,6 +7,7 @@ addons:
     - realpath
 
 jobs:
+  fast_finish: true
   include:
    # Libraries
    - stage: "Libraries"
@@ -169,4 +170,4 @@ after_success:
 
 cache:
   directories:
-   - /home/travis/.conda/pkgs
+   - $HOME/.conda/pkgs

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,16 @@ addons:
     packages:
     - realpath
 
+stages:
+  - "Libraries"
+  - "Binutils"
+  - "GCC - nostdc"
+  - "GCC - newlib"
+  - "GCC - Linux (musl)"
+  - "GDB"
+  - "Toolchain - linux musl"
+  - "Other tools"
+
 jobs:
   fast_finish: true
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,11 @@ jobs:
    - stage: "Libraries"
      env:
      - PACKAGE=lib/isl
+   - stage: "Libraries"
+     os: osx
+     osx_image: xcode8.3
+     env:
+     - PACKAGE=lib/isl
 
    # or1k toolchain
    - stage: "Binutils"
@@ -30,6 +35,12 @@ jobs:
    - stage: "GDB"
      env:
      - PACKAGE=gdb          TOOLCHAIN_ARCH=or1k
+   # OSX
+   - stage: "Binutils"
+     os: osx
+     osx_image: xcode8.3
+     env:
+     - PACKAGE=binutils     TOOLCHAIN_ARCH=or1k
 
    # rv32 toolchain
    - stage: "Binutils"
@@ -47,6 +58,12 @@ jobs:
    - stage: "GDB"
      env:
      - PACKAGE=gdb          TOOLCHAIN_ARCH=riscv32
+   # OSX
+   - stage: "Binutils"
+     os: osx
+     osx_image: xcode8.3
+     env:
+     - PACKAGE=binutils     TOOLCHAIN_ARCH=riscv32
 
    # rv64 toolchain
    - stage: "Binutils"
@@ -64,6 +81,12 @@ jobs:
    - stage: "GDB"
      env:
      - PACKAGE=gdb          TOOLCHAIN_ARCH=riscv64
+   # OSX
+   - stage: "Binutils"
+     os: osx
+     osx_image: xcode8.3
+     env:
+     - PACKAGE=binutils     TOOLCHAIN_ARCH=riscv64
 
    # lm32 toolchain - no linux
    - stage: "Binutils"
@@ -78,6 +101,12 @@ jobs:
    - stage: "GDB"
      env:
      - PACKAGE=gdb          TOOLCHAIN_ARCH=lm32
+   # OSX
+   - stage: "Binutils"
+     os: osx
+     osx_image: xcode8.3
+     env:
+     - PACKAGE=binutils     TOOLCHAIN_ARCH=lm32
 
    # ppc64le toolchain
    - stage: "Binutils"
@@ -95,6 +124,12 @@ jobs:
 #   - stage: "GDB"
 #     env:
 #     - PACKAGE=gdb          TOOLCHAIN_ARCH=ppc64le
+   # OSX
+   - stage: "Binutils"
+     os: osx
+     osx_image: xcode8.3
+     env:
+     - PACKAGE=binutils     TOOLCHAIN_ARCH=ppc64le
 
    # sh2 toolchain
    - stage: "Binutils"
@@ -112,6 +147,12 @@ jobs:
    - stage: "GDB"
      env:
      - PACKAGE=gdb          TOOLCHAIN_ARCH=sh
+   # OSX
+   - stage: "Binutils"
+     os: osx
+     osx_image: xcode8.3
+     env:
+     - PACKAGE=binutils     TOOLCHAIN_ARCH=sh
 
    # Full Linux musl toolchain using musl-cross-make
    - stage: "Toolchain - Linux MUSL"


### PR DESCRIPTION
Those builds were in the 'litex-conda-packages' repository's CI before reorganization.