### PR TITLE
Fix sdcc and macOS compiling problems

### DIFF
--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -1,0 +1,3 @@
+CONDA_BUILD_SYSROOT:
+  - /Users/travis/sdk/MacOSX10.9.sdk        # [osx]
+

--- a/sdcc/meta.yaml
+++ b/sdcc/meta.yaml
@@ -38,12 +38,6 @@ requirements:
     - boost
   run:
     - libboost
-  {% for package in resolved_packages('host') %}
-    - {{ package }}
-  {% endfor %}
-  {% for package in resolved_packages('build') %}
-    - {{ package }}
-  {% endfor %}
 
 test:
   commands:

--- a/sdcc/meta.yaml
+++ b/sdcc/meta.yaml
@@ -44,9 +44,10 @@ requirements:
   {% for package in resolved_packages('build') %}
     - {{ package }}
   {% endfor %}
-  test:
-    commands:
-      - sdcc -v
+
+test:
+  commands:
+    - sdcc -v
 
 about:
   home: http://sdcc.sourceforge.net/


### PR DESCRIPTION
Using all `resolved_packages` as run requirements caused some weird problems with `python` version on Windows. I removed those as they turned out to be excessive.

There were problems lately with `clang` on `macOS` as some packages failed with `configure: error: C compiler cannot create executables`. It turned out the necessary `conda_build_config.yaml` with macOS SDK path got moved to the `.travis`. It still worked unless lately there were some changes in `conda-build` (v20+) resulting in failing macOS builds.