### PR TITLE
Stop using `resolved_packages`

### DIFF
--- a/binutils/meta.yaml
+++ b/binutils/meta.yaml
@@ -23,10 +23,6 @@ requirements:
   build:
    - texinfo
    - {{ compiler('c') }}
-  run:
-  {% for package in resolved_packages('host') %}
-    - {{ package }}
-  {% endfor %}
 
 test:
   commands:

--- a/gcc/nostdc/meta.yaml
+++ b/gcc/nostdc/meta.yaml
@@ -34,10 +34,14 @@ requirements:
     # Arch specific
     - binutils-{{ environ.get('TOOLCHAIN_ARCH') }}-elf
   run:
+    # These are taken from the output of the configure scripts
+    - gmp >=4.3.2
+    - mpfr >=2.4.2
+    - mpc >=0.8.1
+    - isl >=0.15.0
+    - cloog
+    # Arch specific
     - binutils-{{ environ.get('TOOLCHAIN_ARCH') }}-elf
-  {% for package in resolved_packages('host') %}
-    - {{ package }}
-  {% endfor %}
 
 about:
   home: https://gcc.gnu.org/

--- a/gdb/meta.yaml
+++ b/gdb/meta.yaml
@@ -37,9 +37,10 @@ requirements:
     - zlib
   run:
     - binutils-{{ environ.get('TOOLCHAIN_ARCH') }}-elf
-  {% for package in resolved_packages('host') %}
-    - {{ package }}
-  {% endfor %}
+    - expat
+    - mpfr >=2.4.2
+    - ncurses
+    - zlib
     - {{ pin_compatible('python', min_pin='x.x', max_pin='x.x') }}
 
 test:


### PR DESCRIPTION
Using `resolved_packages` in run requirements results in adding exact
builds of the packages used during building as dependencies.

It often leads to dependency conflicts so it's better to have them
copied.

Such changes have been already successfully tested before I erroneously deleted the branch upstream: https://travis-ci.com/github/litex-hub/litex-conda-compilers/builds/202411564

I had to open a new PR because the upstream branch was deleted and then rebased (master branch needed to have upload fixed).