### PR TITLE
Fix recipes to only use Conda-based tools

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -445,7 +445,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'true'
-      - run: brew install coreutils boost
       - uses: litex-hub/litex-conda-ci@master
 
   #33
@@ -459,7 +458,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'true'
-      - run: brew install coreutils boost
       - uses: litex-hub/litex-conda-ci@master
 
   #34
@@ -473,7 +471,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'true'
-      - run: brew install coreutils boost
       - uses: litex-hub/litex-conda-ci@master
 
   #35
@@ -487,7 +484,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'true'
-      - run: brew install coreutils boost
       - uses: litex-hub/litex-conda-ci@master
 
   #36
@@ -501,7 +497,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'true'
-      - run: brew install coreutils boost
       - uses: litex-hub/litex-conda-ci@master
 
   #37

--- a/binutils/meta.yaml
+++ b/binutils/meta.yaml
@@ -21,8 +21,9 @@ build:
 
 requirements:
   build:
-   - texinfo
-   - {{ compiler('c') }}
+    - {{ compiler('c') }}
+    - make
+    - texinfo
 
 test:
   commands:

--- a/gcc/linux-musl/build.sh
+++ b/gcc/linux-musl/build.sh
@@ -17,6 +17,11 @@ else
 	echo "PKG_VERSION: '$PKG_VERSION'"
 fi
 
+cd $BUILD_PREFIX/bin
+ln -s "$AR" ar
+ln -s "$OBJDUMP" objdump
+cd -
+
 if [ x"$TRAVIS" = xtrue ]; then
 	CPU_COUNT=2
 fi

--- a/gcc/linux-musl/condarc
+++ b/gcc/linux-musl/condarc
@@ -1,0 +1,4 @@
+channels:
+  - litex-hub
+  - defaults
+  - conda-forge

--- a/gcc/linux-musl/meta.yaml
+++ b/gcc/linux-musl/meta.yaml
@@ -47,9 +47,11 @@ build:
 
 requirements:
   build:
-    - texinfo
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - file  # Absent in the `main` channel; requires conda-forge.
+    - make
+    - texinfo
   host:
     # These are taken from the output of the configure scripts
     - gmp >=4.3.2

--- a/gcc/newlib/build.sh
+++ b/gcc/newlib/build.sh
@@ -18,6 +18,11 @@ else
 	echo "PKG_VERSION: '$PKG_VERSION'"
 fi
 
+cd $BUILD_PREFIX/bin
+ln -s "$OBJDUMP" objdump
+ln -s "$AR" ar
+cd -
+
 if [ x"$TRAVIS" = xtrue ]; then
 	CPU_COUNT=2
 fi

--- a/gcc/newlib/condarc
+++ b/gcc/newlib/condarc
@@ -1,0 +1,4 @@
+channels:
+  - litex-hub
+  - defaults
+  - conda-forge

--- a/gcc/newlib/meta.yaml
+++ b/gcc/newlib/meta.yaml
@@ -28,6 +28,8 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - file  # Absent in the `main` channel; requires conda-forge.
+    - make
   host:
     # These are taken from the output of the configure scripts
     - gmp >=4.3.2

--- a/gcc/nostdc/build.sh
+++ b/gcc/nostdc/build.sh
@@ -18,6 +18,11 @@ else
 	echo "PKG_VERSION: '$PKG_VERSION'"
 fi
 
+cd $BUILD_PREFIX/bin
+ln -s "$OBJDUMP" objdump
+ln -s "$AR" ar
+cd -
+
 if [ x"$TRAVIS" = xtrue ]; then
 	CPU_COUNT=2
 fi

--- a/gcc/nostdc/meta.yaml
+++ b/gcc/nostdc/meta.yaml
@@ -24,6 +24,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - make
   host:
     # These are taken from the output of the configure scripts
     - gmp >=4.3.2

--- a/gdb/meta.yaml
+++ b/gdb/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - {{ compiler('cxx') }}
     - binutils-{{ environ.get('TOOLCHAIN_ARCH') }}-elf
     - gcc-{{ environ.get('TOOLCHAIN_ARCH') }}-elf-nostdc
+    - make
     - pkg-config
     - python
     - texinfo

--- a/lib/isl/meta.yaml
+++ b/lib/isl/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - clangdev        # [win]
     - lld             # [win]
     - posix           # [win]
+    - make            # [unix]
   host:
     - gmp             # [unix]
   run:

--- a/sdcc/meta.yaml
+++ b/sdcc/meta.yaml
@@ -23,8 +23,11 @@ build:
 
 requirements:
   build:
+    # On macOS tools from coreutils are used
     - {{ compiler('c') }}     [not osx]
     - {{ compiler('cxx') }}   [not osx]
+    - bison                   [linux]
+    - make                    [linux]
     - m2w64-toolchain         [win]
     - m2-bison                [win]
     - m2-patch                [win]

--- a/toolchain/linux-musl/build.sh
+++ b/toolchain/linux-musl/build.sh
@@ -3,6 +3,10 @@
 # gcc newlib build
 set -e
 
+cd $BUILD_PREFIX/bin
+ln -s "$AR" ar
+cd -
+
 if [ -z "${TOOLCHAIN_ARCH}" ]; then
 	export | grep -i toolchain
 	echo "Missing \${TOOLCHAIN_ARCH} env value"

--- a/toolchain/linux-musl/meta.yaml
+++ b/toolchain/linux-musl/meta.yaml
@@ -22,6 +22,8 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - curl
+    - make
   host:
     # These are taken from the output of the configure scripts
     - gmp >=4.3.2
@@ -29,6 +31,8 @@ requirements:
     - mpc >=0.8.1
     - isl >=0.15.0
     - cloog
+  run:
+    - mpc
 
 about:
   home: https://gcc.gnu.org/


### PR DESCRIPTION
After trying to build the recipes on a clean Docker container created from the `ubuntu` image it turned out many of them are relying on the tools preinstalled in the Travis and GitHub Actions Operating Systems.

The changes make all of the recipes buildable without requiring any additional build tools installed in the container.

The changes turned out to be enough to dump installing additional packages through `brew` on macOS in all recipes but `sdcc` that failed to be built with tools installed through Conda.

`file` tool is required to build `gcc/newlib` and `gcc/linux-musl` packages. It is only present in the `conda-forge` channel.

By adding `litex-hub` and `defaults` on top of the `condarc`'s channels, also because of the `channel_priority: strict` setting, only the packages absent in these channels will be taken from the `conda-forge` channel.