### PR TITLE
gcc/newlib: gcc/musl: Allow `file` to fail to get rid of `conda-forge`

### DIFF
--- a/gcc/linux-musl/build.sh
+++ b/gcc/linux-musl/build.sh
@@ -82,7 +82,7 @@ bash $RECIPE_DIR/step4-libc.sh
 echo -n "---?"
 which $LINUX_TARGET-gcc
 ls -l $(which $LINUX_TARGET-gcc)
-file $(which $LINUX_TARGET-gcc)
+file $(which $LINUX_TARGET-gcc) || true
 echo "---"
 $LINUX_TARGET-gcc --version 2>&1
 echo "---"

--- a/gcc/linux-musl/condarc
+++ b/gcc/linux-musl/condarc
@@ -1,4 +1,0 @@
-channels:
-  - litex-hub
-  - defaults
-  - conda-forge

--- a/gcc/linux-musl/meta.yaml
+++ b/gcc/linux-musl/meta.yaml
@@ -44,8 +44,6 @@ build:
     - 'libexec/**/gcc'
     - 'libexec/**/lto*'
     - 'libexec/**/plugin/gengtype'
-  ignore_run_exports_from:
-    - file  # To make sure there are no run requirements from conda-forge
 
 requirements:
   build:
@@ -54,7 +52,6 @@ requirements:
     - make
     - texinfo
   host:
-    - file  # Absent in the `main` channel; requires conda-forge.
     # These are taken from the output of the configure scripts
     - gmp >=4.3.2
     - mpfr >=2.4.2

--- a/gcc/linux-musl/step0-binutils.sh
+++ b/gcc/linux-musl/step0-binutils.sh
@@ -35,7 +35,7 @@ cd $SRC_DIR
 echo -n "---?"
 which $LINUX_TARGET-as
 ls -l $(which $LINUX_TARGET-as)
-file $(which $LINUX_TARGET-as)
+file $(which $LINUX_TARGET-as) || true
 echo "---"
 $LINUX_TARGET-as --version 2>&1
 echo "---"

--- a/gcc/linux-musl/step1-stage1-gcc.sh
+++ b/gcc/linux-musl/step1-stage1-gcc.sh
@@ -53,7 +53,7 @@ cd $SRC_DIR
 echo -n "---?"
 which $LINUX_TARGET-gcc
 ls -l $(which $LINUX_TARGET-gcc)
-file $(which $LINUX_TARGET-gcc)
+file $(which $LINUX_TARGET-gcc) || true
 echo "---"
 $LINUX_TARGET-gcc --version 2>&1
 echo "---"

--- a/gcc/linux-musl/step3-stage2-gcc.sh
+++ b/gcc/linux-musl/step3-stage2-gcc.sh
@@ -57,7 +57,7 @@ cd $SRC_DIR
 echo -n "---?"
 which $LINUX_TARGET-gcc
 ls -l $(which $LINUX_TARGET-gcc)
-file $(which $LINUX_TARGET-gcc)
+file $(which $LINUX_TARGET-gcc) || true
 echo "---"
 $LINUX_TARGET-gcc --version 2>&1
 echo "---"

--- a/gcc/newlib/build.sh
+++ b/gcc/newlib/build.sh
@@ -79,7 +79,7 @@ $TARGET-as --version
 echo -n "---?"
 which $TARGET-gcc
 ls -l $(which $TARGET-gcc)
-file $(which $TARGET-gcc)
+file $(which $TARGET-gcc) || true
 echo "---"
 $TARGET-gcc --version 2>&1
 echo "---"

--- a/gcc/newlib/condarc
+++ b/gcc/newlib/condarc
@@ -1,4 +1,0 @@
-channels:
-  - litex-hub
-  - defaults
-  - conda-forge

--- a/gcc/newlib/meta.yaml
+++ b/gcc/newlib/meta.yaml
@@ -23,8 +23,6 @@ build:
     - CI
     - TRAVIS
     - TOOLCHAIN_ARCH
-  ignore_run_exports_from:
-    - file  # To make sure there are no run requirements from conda-forge
 
 requirements:
   build:
@@ -32,7 +30,6 @@ requirements:
     - {{ compiler('cxx') }}
     - make
   host:
-    - file  # Absent in the `main` channel; requires conda-forge.
     # These are taken from the output of the configure scripts
     - gmp >=4.3.2
     - mpfr >=2.4.2


### PR DESCRIPTION
Conda is lately finding weird conflicts with compilers whenever
`conda-forge` (needed only for the `file` package) is used along the
`defaults` channel.

Since the `file` tool is only called to print some debug information,
its failure was made acceptable in the build scripts of `gcc/linux-musl`
and `gcc/newlib`.

Fixes #21.